### PR TITLE
fix compressor test portability

### DIFF
--- a/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/AbstractCompressorTest.java
+++ b/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/AbstractCompressorTest.java
@@ -27,13 +27,11 @@ public abstract class AbstractCompressorTest {
 
     protected abstract Codec getCodec();
     
-    protected abstract int expectedCompressedSize();
-    
     @Test
     public void codecTest() throws Exception {
         log.info("Codec: "+getCodec().toString());
         
-        assertEquals(2927, testFile.contentLength());
+        long fileLength = testFile.contentLength();
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
 
         StopWatch compressionStopWatch = new StopWatch();
@@ -45,7 +43,7 @@ public abstract class AbstractCompressorTest {
         compressionStopWatch.endAndLog("Compression");
 
         byte[] compressedData = bos.toByteArray();
-        assertEquals(expectedCompressedSize(), compressedData.length);
+        assertTrue("Compressed file size should be less than original", compressedData.length < fileLength);
 
         InputStream bis = new ByteArrayInputStream(compressedData);
         ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
@@ -57,7 +55,7 @@ public abstract class AbstractCompressorTest {
         decompressionStopWatch.endAndLog("Decompression");
         
         byte[] decompressedData = bos2.toByteArray();
-        assertEquals(2927, decompressedData.length);
+        assertEquals(decompressedData.length, fileLength);
 
         try (InputStream is = testFile.getInputStream()) {
             assertTrue(IOUtils.contentEquals(is, new ByteArrayInputStream(bos2.toByteArray())));

--- a/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/Bzip2CompressorTest.java
+++ b/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/Bzip2CompressorTest.java
@@ -6,11 +6,6 @@ import net.kiberion.utils.compression.impl.BZip2Codec;
 public class Bzip2CompressorTest extends AbstractCompressorTest{
 
     @Override
-    protected int expectedCompressedSize() {
-        return 626;
-    }
-    
-    @Override
     protected Codec getCodec() {
         return new BZip2Codec();
     }

--- a/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/SevenZCompressorTest.java
+++ b/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/SevenZCompressorTest.java
@@ -6,11 +6,6 @@ import net.kiberion.utils.compression.impl.SevenZCodec;
 public class SevenZCompressorTest extends AbstractCompressorTest{
 
     @Override
-    protected int expectedCompressedSize() {
-        return 645;
-    }
-    
-    @Override
     protected Codec getCodec() {
         return new SevenZCodec();
     }

--- a/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/SnappyCompressorTest.java
+++ b/swampmachine-utils/src/test/java/net/kiberion/swampmachine/utils/SnappyCompressorTest.java
@@ -6,11 +6,6 @@ import net.kiberion.utils.compression.impl.SnappyCodec;
 public class SnappyCompressorTest extends AbstractCompressorTest{
 
     @Override
-    protected int expectedCompressedSize() {
-        return 827;
-    }
-    
-    @Override
     protected Codec getCodec() {
         return new SnappyCodec();
     }


### PR DESCRIPTION
- replace hardcoded file length value with dynamic check
- do not check for exact compressed size as it may vary